### PR TITLE
fix path env for remixd in gui mode

### DIFF
--- a/main.js
+++ b/main.js
@@ -151,6 +151,7 @@ function getFolder(client) {
 let remixdStart = () => {
   // electron GUI does not inherit the path from the terminal, this is a workaround
   fixPath()
+  console.log('start shared folder service')
   try {
     startService('folder', (ws, client) => {
       client.setWebSocket(ws)

--- a/main.js
+++ b/main.js
@@ -5,6 +5,7 @@ const os = require('os')
 const fetch = require('node-fetch')
 const semver = require('semver')
 const config = require('./config')
+const fixPath = require('fix-path')
 
 const { version } = require('./package.json')
 const applicationMenu = require('./applicationMenu')
@@ -148,7 +149,8 @@ function getFolder(client) {
 }
 
 let remixdStart = () => {
-  console.log('start shared folder service')
+  // electron GUI does not inherit the path from the terminal, this is a workaround
+  fixPath()
   try {
     startService('folder', (ws, client) => {
       client.setWebSocket(ws)

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "fs-extra": "^3.0.1",
     "latest-version": "^5.1.0",
     "node-fetch": "^2.6.1",
-    "semver": "^7.3.5"
+    "semver": "^7.3.5",
+    "fix-path": "3.0.0"
   }
 }


### PR DESCRIPTION
When electron is run in GUI stand alone mode the env from the shell is not inherited so the remixd commands ( node, npx etc ) can't be found, this fix-path package gets the env from the main shell. needs to be extensively tested on different platforms by 
- yarn dist 
- and then installing the package generated ( dmg etc )
- and running the app 
- open a hardhat project in localhost 
- 'enable hardhat compile' in remix
- compile the hardhat contract from remix ide, it should not have an error